### PR TITLE
Quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,7 @@ keywords = ["vlq", "sourcemap"]
 repository = "https://github.com/tromey/vlq"
 license = "Apache-2.0/MIT"
 
+[dev-dependencies]
+quickcheck = "0.5.0"
+
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,4 +138,12 @@ mod tests {
             decode_tester_ok(&buf, val);
         }
     }
+
+    #[test]
+    fn test_simple_roundtrip() {
+        for val in 0..64 {
+            // Don't crash, and decoding is an identity.
+            assert_eq!(val, super::decode64(super::encode64(val)).unwrap());
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,37 +108,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    fn decode_tester_ok(input: &[u8], expect: i64) {
-        let mut input = input.iter().cloned();
-        match ::decode(&mut input) {
-            Ok(x) => {
-                assert_eq!(x, expect);
-                assert!(input.next().is_none());
-            }
-            _ => assert!(false),
-        }
-    }
-
-    #[test]
-    fn test_decode() {
-        decode_tester_ok("A".as_bytes(), 0);
-        decode_tester_ok("B".as_bytes(), 0);
-        decode_tester_ok("C".as_bytes(), 1);
-        decode_tester_ok("D".as_bytes(), -1);
-    }
-
-    #[test]
-    fn test_roundtrip() {
-        for val in -512..512 {
-            let mut buf = Vec::<u8>::new();
-            match ::encode(val, &mut buf) {
-                Ok(()) => assert!(buf.len() > 0),
-                _ => assert!(false),
-            }
-            decode_tester_ok(&buf, val);
-        }
-    }
-
     #[test]
     fn test_simple_roundtrip() {
         for val in 0..64 {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,0 +1,37 @@
+#[macro_use]
+extern crate quickcheck;
+extern crate vlq;
+
+use vlq::{decode, encode};
+
+// Encode a single base64 digit.
+fn encode64(value: u8) -> u8 {
+    debug_assert!(value < 64);
+    if value < 26 {
+        value + b'A'
+    } else if value < 52 {
+        value - 26 + b'a'
+    } else if value < 62 {
+        value - 52 + b'0'
+    } else if value == 62 {
+        b'+'
+    } else {
+        assert!(value == 63);
+        b'/'
+    }
+}
+
+quickcheck! {
+    fn parse_check(inputs: Vec<u8>) -> () {
+        let mut coded = inputs.into_iter().map(|x| {
+            encode64(x & 63)
+        });
+        let _ = decode(&mut coded);
+    }
+
+    fn roundtrip(x: i64) -> bool {
+        let mut buf = vec![];
+        encode(x, &mut buf).unwrap();
+        decode(&mut buf.iter().cloned()).unwrap() == x
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,35 @@
+extern crate vlq;
+
+use vlq::{decode, encode};
+
+fn decode_tester_ok(input: &[u8], expect: i64) {
+    let mut input = input.iter().cloned();
+    match decode(&mut input) {
+        Ok(x) => {
+            assert_eq!(x, expect);
+            assert!(input.next().is_none());
+        }
+        _ => assert!(false),
+    }
+}
+
+#[test]
+fn test_decode() {
+    decode_tester_ok("A".as_bytes(), 0);
+    decode_tester_ok("B".as_bytes(), 0);
+    decode_tester_ok("C".as_bytes(), 1);
+    decode_tester_ok("D".as_bytes(), -1);
+}
+
+#[test]
+fn test_roundtrip() {
+    for val in -512..512 {
+        let mut buf = Vec::<u8>::new();
+        match encode(val, &mut buf) {
+            Ok(()) => assert!(buf.len() > 0),
+            _ => assert!(false),
+        }
+        decode_tester_ok(&buf, val);
+    }
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate vlq;
 
-use vlq::{decode, encode};
+use vlq::{decode, encode, Error};
 
 fn decode_tester_ok(input: &[u8], expect: i64) {
     let mut input = input.iter().cloned();
@@ -33,3 +33,20 @@ fn test_roundtrip() {
     }
 }
 
+#[test]
+fn test_wrapping() {
+    let inputs = &[
+        &b"////////////////////////////A"[..],
+        &b"////////////P"[..],
+        ];
+
+    for input in inputs {
+        match decode(&mut input.iter().cloned()) {
+            Err(Error::Overflow) => {},
+            Ok(val) => {
+                println!("WHAT?? {} {:x}", val, i64::max_value());
+            },
+            _ => assert!(false),
+        }
+    }
+}


### PR DESCRIPTION
Here's what I tried - can you review it?  Since I suspect I'm not using quickcheck properly.

This didn't turn up any crashes, but I think that's because the decoder is careful to use `u64` when shifting.  However perhaps we ought to be checking for overflow in there, rather than letting bad encodings silently slip through.