### PR TITLE
Handle the full i64 range of values

### DIFF
--- a/examples/mapdump.rs
+++ b/examples/mapdump.rs
@@ -51,7 +51,7 @@ fn main() {
                     println!("   orig column {}", orig_column);
 
                     match decode(input.by_ref()) {
-                        Err(_) => {},
+                        Err(_) => {}
                         Ok(n) => {
                             name_number += n;
                             println!("   name #{}", name_number);

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -31,11 +31,6 @@ quickcheck! {
     }
 
     fn roundtrip(x: i64) -> bool {
-        // The single `i64` value that we cannot round trip.
-        if x == i64::MIN {
-            return true;
-        }
-
         let mut buf = vec![];
         encode(x, &mut buf).unwrap();
         decode(&mut buf.iter().cloned()).unwrap() == x


### PR DESCRIPTION
This fixes a few of the calcualtions necessary to handle `i64::MIN`:

- Encoding `i64::MIN` (which has only a sign bit, and 0s elsewhere) translates into `0`. It's then `|= 1`, which is unique when decoding.
- Decoding `1` (which implies a negative number, but its value is zero) can then be read back as `i64::MIN`.

I also opted to explicitly handle the overflow cases, so that the test became apparent what the error cases are.